### PR TITLE
fixed websocket issue

### DIFF
--- a/deribit_ws.py
+++ b/deribit_ws.py
@@ -35,10 +35,13 @@ class WS_Client(object):
                 # send a private subscription request
                 if "private/subscribe" in request:
                     await websocket.send(request)
-                    while websocket.open:
-                        response = await websocket.recv()
-                        response = json.loads(response)
-                        print(response)
+                    while True:
+                        try:
+                            response = await websocket.recv()
+                            response = json.loads(response)
+                            # print(response)
+                        except websockets.exceptions.ConnectionClosed:
+                            break
 
                 # send a private method request
                 else:
@@ -60,10 +63,13 @@ class WS_Client(object):
     async def public_sub(self, request):
         async with websockets.connect(self.client_url) as websocket:
             await websocket.send(request)
-            while websocket.open:
-                response = await websocket.recv()
-                response = json.loads(response)
-                print(response)
+            while True:
+                try:
+                    response = await websocket.recv()
+                    response = json.loads(response)
+                    # print(response)
+                except websockets.exceptions.ConnectionClosed:
+                    break
 
     # create an asyncio event loop
     def loop(self, api, request):


### PR DESCRIPTION
fixed compatibility issue with websocket. the open property was no longer available. 

as per their documentation:

https://websockets.readthedocs.io/en/stable/reference/legacy/client.html#websockets.legacy.client.WebSocketClientProtocol.open
    [True](https://docs.python.org/3/library/constants.html#True) when the connection is open; [False](https://docs.python.org/3/library/constants.html#False) otherwise.

    This attribute may be used to detect disconnections. However, this approach is discouraged per the [EAFP](https://docs.python.org/3/glossary.html#term-eafp) principle. Instead, you should handle [ConnectionClosed](https://websockets.readthedocs.io/en/stable/reference/exceptions.html#websockets.exceptions.ConnectionClosed) exceptions.
    
    